### PR TITLE
Add repository pattern for JobType API

### DIFF
--- a/1-Presentation/api/Functions/JobTypeFunctions.cs
+++ b/1-Presentation/api/Functions/JobTypeFunctions.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using HotshotLogistics.Core.Models;
+using HotshotLogistics.Core.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Text.Json;
+
+namespace HotshotLogistics.Api.Functions;
+
+public class JobTypeFunctions
+{
+    private readonly IJobTypeRepository _repository;
+
+    public JobTypeFunctions(IJobTypeRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [Function("GetJobTypes")]
+    public async Task<HttpResponseData> GetJobTypes(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "jobtypes")] HttpRequestData req)
+    {
+        var jobTypes = await _repository.GetAllAsync();
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(jobTypes);
+        return response;
+    }
+
+    [Function("GetJobType")]
+    public async Task<HttpResponseData> GetJobType(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "jobtypes/{id}")] HttpRequestData req,
+        int id)
+    {
+        var jobType = await _repository.GetByIdAsync(id);
+        if (jobType == null)
+        {
+            var notFoundResponse = req.CreateResponse(HttpStatusCode.NotFound);
+            await notFoundResponse.WriteStringAsync($"Job type with ID {id} not found");
+            return notFoundResponse;
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(jobType);
+        return response;
+    }
+
+    [Function("CreateJobType")]
+    public async Task<HttpResponseData> CreateJobType(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "jobtypes")] HttpRequestData req)
+    {
+        var jobType = await JsonSerializer.DeserializeAsync<JobType>(req.Body);
+        if (jobType == null)
+        {
+            var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await badRequestResponse.WriteStringAsync("Invalid job type data");
+            return badRequestResponse;
+        }
+
+        await _repository.AddAsync(jobType);
+
+        var response = req.CreateResponse(HttpStatusCode.Created);
+        await response.WriteAsJsonAsync(jobType);
+        return response;
+    }
+}

--- a/1-Presentation/api/Program.cs
+++ b/1-Presentation/api/Program.cs
@@ -1,5 +1,7 @@
 using Azure.Identity;
 using HotshotLogistics.Infrastructure.Data;
+using HotshotLogistics.Core.Interfaces;
+using HotshotLogistics.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,7 +35,8 @@ var host = new HostBuilder()
         services.AddDbContext<HotshotDbContext>(options =>
             options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
 
-        // Add other services here
+        // Register repositories
+        services.AddScoped<IJobTypeRepository, JobTypeRepository>();
     })
     .Build();
 

--- a/2-Application/Interfaces/IJobTypeRepository.cs
+++ b/2-Application/Interfaces/IJobTypeRepository.cs
@@ -1,0 +1,10 @@
+namespace HotshotLogistics.Core.Interfaces;
+
+using HotshotLogistics.Core.Models;
+
+public interface IJobTypeRepository
+{
+    Task<List<JobType>> GetAllAsync();
+    Task<JobType?> GetByIdAsync(int id);
+    Task<JobType> AddAsync(JobType jobType);
+}

--- a/2-Application/Models/JobType.cs
+++ b/2-Application/Models/JobType.cs
@@ -1,0 +1,7 @@
+namespace HotshotLogistics.Core.Models;
+
+public class JobType
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/4-Persistence/Data/HotshotDbContext.cs
+++ b/4-Persistence/Data/HotshotDbContext.cs
@@ -10,6 +10,7 @@ public class HotshotDbContext : DbContext
     }
 
     public DbSet<Driver> Drivers { get; set; }
+    public DbSet<JobType> JobTypes { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -26,5 +27,11 @@ public class HotshotDbContext : DbContext
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.UpdatedAt).ValueGeneratedOnUpdate();
         });
+
+        modelBuilder.Entity<JobType>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+        });
     }
-} 
+}

--- a/4-Persistence/HotshotLogistics.Infrastructure/HotshotLogistics.Infrastructure.csproj
+++ b/4-Persistence/HotshotLogistics.Infrastructure/HotshotLogistics.Infrastructure.csproj
@@ -5,5 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\2-Application\HotshotLogistics.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/4-Persistence/Repositories/JobTypeRepository.cs
+++ b/4-Persistence/Repositories/JobTypeRepository.cs
@@ -1,0 +1,33 @@
+using HotshotLogistics.Core.Interfaces;
+using HotshotLogistics.Core.Models;
+using HotshotLogistics.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace HotshotLogistics.Infrastructure.Repositories;
+
+public class JobTypeRepository : IJobTypeRepository
+{
+    private readonly HotshotDbContext _context;
+
+    public JobTypeRepository(HotshotDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<JobType>> GetAllAsync()
+    {
+        return await _context.JobTypes.ToListAsync();
+    }
+
+    public async Task<JobType?> GetByIdAsync(int id)
+    {
+        return await _context.JobTypes.FindAsync(id);
+    }
+
+    public async Task<JobType> AddAsync(JobType jobType)
+    {
+        var entry = await _context.JobTypes.AddAsync(jobType);
+        await _context.SaveChangesAsync();
+        return entry.Entity;
+    }
+}


### PR DESCRIPTION
## Summary
- add `IJobTypeRepository` interface to core
- implement `JobTypeRepository` in infrastructure
- register repository in API Program
- refactor `JobTypeFunctions` to use repository
- reference EF Core packages in infrastructure project

## Testing
- `dotnet test 5-Test/tests/HotshotLogistics.Tests/HotshotLogistics.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684905e7a7648321a963229176245b04