### PR TITLE
Add .NET CI pipeline with architecture checks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,45 @@
+name: .NET CI
+
+on:
+  push:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '.github/workflows/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore
+        run: |
+          for proj in $(find . -name '*.csproj'); do
+            dotnet restore "$proj"
+          done
+      - name: Install formatter
+        run: dotnet tool update -g dotnet-format
+      - name: Lint
+        run: |
+          export PATH="$HOME/.dotnet/tools:$PATH"
+          for proj in $(find . -name '*.csproj'); do
+            dotnet format "$proj" --verify-no-changes --no-restore
+          done
+      - name: Build
+        run: |
+          for proj in $(find . -name '*.csproj'); do
+            dotnet build "$proj" --configuration Release --no-restore
+          done
+      - name: Test
+        run: |
+          for proj in $(find ./5-Test -name '*.csproj'); do
+            dotnet test "$proj" --no-build --configuration Release
+          done

--- a/5-Test/tests/HotshotLogistics.Tests/ArchitectureTests.cs
+++ b/5-Test/tests/HotshotLogistics.Tests/ArchitectureTests.cs
@@ -1,0 +1,48 @@
+using NetArchTest.Rules;
+using Xunit;
+using HotshotLogistics.Domain.Models;
+using HotshotLogistics.Application.Services;
+using HotshotLogistics.Data.Repositories;
+
+namespace HotshotLogistics.Tests;
+
+public class ArchitectureTests
+{
+    private const string Presentation = "HotshotLogistics.Api";
+    private const string Infrastructure = "HotshotLogistics.Infrastructure";
+    private const string Application = "HotshotLogistics.Application";
+    private const string Data = "HotshotLogistics.Data";
+
+    [Fact]
+    public void Domain_should_not_depend_on_other_layers()
+    {
+        var result = Types.InAssembly(typeof(Driver).Assembly)
+            .ShouldNot()
+            .HaveDependencyOnAny(Application, Data, Infrastructure, Presentation)
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, string.Join(',', result.FailingTypeNames));
+    }
+
+    [Fact]
+    public void Application_should_not_depend_on_presentation()
+    {
+        var result = Types.InAssembly(typeof(DriverService).Assembly)
+            .ShouldNot()
+            .HaveDependencyOn(Presentation)
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, string.Join(',', result.FailingTypeNames));
+    }
+
+    [Fact]
+    public void Repositories_should_be_internal()
+    {
+        var result = Types.InAssembly(typeof(DriverRepository).Assembly)
+            .That().HaveNameEndingWith("Repository")
+            .Should().NotBePublic()
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, string.Join(',', result.FailingTypeNames));
+    }
+}

--- a/5-Test/tests/HotshotLogistics.Tests/HotshotLogistics.Tests.csproj
+++ b/5-Test/tests/HotshotLogistics.Tests/HotshotLogistics.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add GitHub workflow for building and linting C# projects
- install architecture rules tests in unit test project
- add architecture tests enforcing Clean Architecture layer dependencies

## Testing
- `dotnet build 1-Presentation/HotshotLogistics.Api/HotshotLogistics.Api.csproj -c Release --no-restore`
- `dotnet test 5-Test/tests/HotshotLogistics.Tests/HotshotLogistics.Tests.csproj --no-build --configuration Release` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684a2bf3c19c8321960e37a4547232d4