### PR TITLE
Prevent Dependabot .NET bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions" 
+      - "github-actions"
+    ignore:
+      # Avoid automatic upgrades of our .NET version
+      - dependency-name: "actions/setup-dotnet"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- update Dependabot config to ignore .NET major version updates

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859de29e2508321950bdf30042f3a1c