### PR TITLE
Fix CI double run

### DIFF
--- a/.github/workflows/dotnet-buid-test.yml
+++ b/.github/workflows/dotnet-buid-test.yml
@@ -1,11 +1,6 @@
 name: Dot Net API Build and Test
 
 on:
-  push:
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '.github/workflows/**'
   pull_request:
     paths:
       - '**/*.cs'


### PR DESCRIPTION
## Summary
- remove `push` trigger from Dot Net CI

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a23e284f08321aa40d15eca32eebe