### PR TITLE
Update gitignore to exclude VS Code files

### DIFF
--- a/.cursor/rules/stylecop.mdc
+++ b/.cursor/rules/stylecop.mdc
@@ -1,5 +1,0 @@
----
-description:
-globs:
-alwaysApply: false
----

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,13 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
-.vscode
+.cursor
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
## Summary
- ignore local .cursor folder
- fine-tune `.vscode` rule to keep common config JSON files
- drop tracked .cursor data

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a29e795208321b3b63daa97b657c6