### PR TITLE
Add Claude CLI workflow

### DIFF
--- a/.github/workflows/claude-cli.yml
+++ b/.github/workflows/claude-cli.yml
@@ -1,0 +1,29 @@
+name: Run Claude CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt to send to Claude'
+        required: true
+        type: string
+
+jobs:
+  run-claude:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install anthropic-cli
+        run: pip install anthropic-cli
+
+      - name: Run Claude CLI
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: anthropic-cli -g user "${{ inputs.prompt }}"

--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ See future `CONTRIBUTING.md` for guidelines.
 
 ---
 
+## 🤖 Claude CLI GitHub Action
+
+Run the workflow in `.github/workflows/claude-cli.yml` to test prompts against Claude.
+Create a repository secret named `ANTHROPIC_API_KEY` with your API token; the workflow passes this secret to the CLI.
+Provide your prompt when manually dispatching the workflow from the **Actions** tab.
+
+
+---
+
 ## ✨ Credits
 
 - Built with [Next.js](https://nextjs.org/), [Expo](https://expo.dev/), [.NET](https://dotnet.microsoft.com/), [Azure](https://azure.microsoft.com/), [SQL Server](https://www.microsoft.com/en-us/sql-server/sql-server-2022), and more.


### PR DESCRIPTION
## Summary
- add GitHub action to run Claude CLI with a prompt parameter
- document new workflow and secret configuration in README

## Testing
- `dotnet test 5-Test/tests/HotshotLogistics.Tests/HotshotLogistics.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5d61770883219c06901e37afeb22